### PR TITLE
Fixes "Too many open files"

### DIFF
--- a/src/LDX/EasyRank/Main.php
+++ b/src/LDX/EasyRank/Main.php
@@ -12,10 +12,7 @@ class Main extends PluginBase {
     $this->getLogger()->info(TextFormat::YELLOW . "Loading EasyRank v" . $this->getDescription()->getVersion() . " by LDX...");
   }
   public function onEnable() {
-    if(!file_exists($this->getDataFolder() . "config.yml")) {
-      @mkdir($this->getDataFolder());
-      file_put_contents($this->getDataFolder() . "config.yml",$this->getResource("config.yml"));
-    }
+    $this->saveDefaultConfig();
     $this->getServer()->getPluginManager()->registerEvents($this,$this);
     $this->getLogger()->info(TextFormat::YELLOW . "Enabling EasyRank...");
   }


### PR DESCRIPTION
This fixes issues with not closing resources given by PocketMine, causing a crash at a later stage.
Users usually blame PocketMine for this, but it's entirely a plugin's fault.

This code was found via GitHub search, please review your code for usage of:
- `Plugin->getResource()` without `fclose()` calls later
- Not needed `Plugin->getResource()` calls
- `fopen()` calls without `fclose()`
- `popen()` calls without `pclose()`
